### PR TITLE
Fix runtime error on v.client.Do()

### DIFF
--- a/request.go
+++ b/request.go
@@ -19,6 +19,10 @@ func (v *Viber) PostData(url string, i interface{}) ([]byte, error) {
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(b))
 	req.Header.Add("X-Viber-Auth-Token", v.AppKey)
 	req.Close = true
+	
+	if v.client == nil {
+		v.client = &http.Client{}
+	}
 
 	resp, err := v.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Error catched on sending message after webhook handling.

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x96f422]

When we handle webhooks from viber, we create instance by this way:

```
v := &viber.Viber{
		AppKey: token,
		Sender: viber.Sender{
			Name:   "MyPage",
			Avatar: "https://mysite.com/img/avatar.jpg",
		},
		//Message:   msgReceivedFunc,
		//Delivered: deliveredFunc,
}
```

May be this is bad way, and we need to use .New() method everywhere, beause v.client is nil. 

My fix: just check and init &http.Client{} if client is nil.


