### PR TITLE
Add input field state for device keyboard

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -1,16 +1,31 @@
 package viber
 
+type InputFieldStateType string
+
+// InputFieldState Values
+const (
+	RegularState   = InputFieldStateType("regular")
+	MinimizedState = InputFieldStateType("minimized")
+	HiddenState    = InputFieldStateType("hidden")
+)
+
 // Keyboard struct
 type Keyboard struct {
-	Type          string   `json:"Type"`
-	DefaultHeight bool     `json:"DefaultHeight,omitempty"`
-	BgColor       string   `json:"BgColor,omitempty"`
-	Buttons       []Button `json:"Buttons"`
+	Type            string              `json:"Type"`
+	DefaultHeight   bool                `json:"DefaultHeight,omitempty"`
+	BgColor         string              `json:"BgColor,omitempty"`
+	Buttons         []Button            `json:"Buttons"`
+	InputFieldState InputFieldStateType `json:"InputFieldState,omitempty"`
 }
 
 // AddButton to keyboard
 func (k *Keyboard) AddButton(b *Button) {
 	k.Buttons = append(k.Buttons, *b)
+}
+
+func (k *Keyboard) SetInputFieldState(state InputFieldStateType) *Keyboard {
+	k.InputFieldState = state
+	return k
 }
 
 // NewKeyboard struct with attribs init


### PR DESCRIPTION
According to docs from Viber it's possible to set other keyboard state than default or even hide it

https://viber.github.io/docs/tools/keyboards/

Set `min_api_version = 4` in message struct to make it work properly.